### PR TITLE
Update concurrency back to shared, bump prometheus-client to v1.0.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,12 +21,14 @@ jobs:
         apt-get update
         apt-get install -y --no-install-recommends git
     - name: Install deps and run RSpec
+      env:
+        CI_GEM_NAME: logstash-output-prom.gem
       run: script/cibuild
     - name: Upload build artifact
       uses: actions/upload-artifact@v1
       with:
         name: gem
-        path: logstash-output-prometheus-0.1.2.gem
+        path: logstash-output-prom.gem
   end-to-end:
     needs: build-test
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.3
+  - Threading problem was proven to be caused by another plugin, unrelated to us. Reverting to a shard concurrency model
+  - Upgraded prometheus/client to v1.0.0
 ## 0.1.2
   - Set to be a single threaded plugin while investigation into deadlocks occurs.
 ## 0.1.1

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 gem 'logstash-core'
 gem 'logstash-core-plugin-api'
 
-gem 'prometheus-client', "0.10.0.pre.alpha.2"
+gem 'prometheus-client', "1.0.0"
 gem "rack", ">= 1.6.11"
 
 gem 'logstash-devutils', ">= 1.3.1", :group => [:development]

--- a/README.md
+++ b/README.md
@@ -99,4 +99,9 @@ output {
 
 As outlined in https://www.robustperception.io/putting-queues-in-front-of-prometheus-for-reliability, putting a queue in front of Prometheus can have negative effects. When doing this, please ensure you are monitoring the time it takes events to pass through your queue.
 
-This is currently a beta plugin, and does not yet have official logstash adoption. One of the big things holding us back is that `prometheus-client` over at https://github.com/prometheus/client_ruby is still in alpha.
+## Steps towards a 1.0 release
+
+Things needed for a 1.0 release:
+- Official logstash adoption (nice to have). See: https://github.com/elastic/logstash/issues/11153
+- ~`prometheus-client` over at https://github.com/prometheus/client_ruby is still in alpha.~ This has now been solved.
+- A stable release without known errors for one month.

--- a/lib/logstash/outputs/prometheus.rb
+++ b/lib/logstash/outputs/prometheus.rb
@@ -8,7 +8,7 @@ require 'prometheus/client'
 # An prometheus output that does nothing.
 class LogStash::Outputs::Prometheus < LogStash::Outputs::Base
   config_name "prometheus"
-  concurrency :single
+  concurrency :shared
 
   config :port, :validate => :number, :default => 9640
 

--- a/logstash-output-prometheus.gemspec
+++ b/logstash-output-prometheus.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-prometheus'
-  s.version       = '0.1.2'
+  s.version       = '0.1.3'
   s.licenses      = ['Apache-2.0']
   s.summary       = 'Output logstash data to a prometheus exporter'
 #  s.homepage      = 'Nada'
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
   s.add_runtime_dependency "logstash-codec-plain"
-  s.add_runtime_dependency "prometheus-client", "0.10.0.pre.alpha.2"
+  s.add_runtime_dependency "prometheus-client", "1.0.0"
   s.add_runtime_dependency "rack", ">= 1.6.11"
 
   s.add_development_dependency "logstash-devutils", "~> 1.3", ">= 1.3.1"

--- a/script/build
+++ b/script/build
@@ -9,4 +9,4 @@ bundle install --jobs 4 --retry 3
 gem build logstash-output-prometheus.gemspec
 
 echo "Successfully built! Install in your logstash by running..."
-echo "logstash-plugin install $PWD/logstash-output-prometheus-0.1.2.gem from your logstash directory"
+echo "logstash-plugin install $PWD/logstash-output-prometheus-0.1.3.gem from your logstash directory"

--- a/script/build
+++ b/script/build
@@ -8,5 +8,11 @@ bundle install --jobs 4 --retry 3
 
 gem build logstash-output-prometheus.gemspec
 
-echo "Successfully built! Install in your logstash by running..."
-echo "logstash-plugin install $PWD/logstash-output-prometheus-0.1.3.gem from your logstash directory"
+if [[ -z "${CI_GEM_NAME-}" ]]; then
+	echo "Successfully built! Install in your logstash by running..."
+	echo "logstash-plugin install $PWD/logstash-output-prometheus-0.1.3.gem from your logstash directory"
+else
+	echo "Successfully built!"
+	# Makes the assumption that there is only one build.
+	mv logstash-output-prometheus*.gem "${CI_GEM_NAME}"
+fi


### PR DESCRIPTION
This will also cut us `0.1.3`, and includes a readme update to outline what is needed for a v1.0 release for us, now that our core dependency is stable.