### PR TITLE
Implement "by" field for increment/decrements

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ output {
 				labels => {
 					value => "%{[message]}"
 				}
-				by => "1"}
+				by => "1"
 				type => "counter"
 			}
 		}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For more information about contributing, see the [CONTRIBUTING](https://github.c
 ## Examples
 
 ```
-logstash -e 'input { stdin { } } 
+logstash -e 'input { stdin { } }
 filter {
 	mutate {
 		add_field => {
@@ -52,7 +52,7 @@ output {
 				type => "histogram"
 				buckets => [0.1, 1, 5, 10]
 				labels => {
-					mylabel => "testlabel" 
+					mylabel => "testlabel"
 				}
 			}
 		}
@@ -71,15 +71,16 @@ output {
 ```
 
 ```
-logstash -e 'input { stdin { } } 
+logstash -e 'input { stdin { } }
 output {
 	prometheus {
 		increment => {
 			mycounter => {
 				description => "This is my test counter"
 				labels => {
-					value => "%{[message]}" 
+					value => "%{[message]}"
 				}
+                by => "1"
 				type => "counter"
 			}
 		}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ output {
 				labels => {
 					value => "%{[message]}"
 				}
-                by => "1"
+				by => "1"}
 				type => "counter"
 			}
 		}

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -43,10 +43,11 @@ Use cases include but are not limited to:
 |=======================================================================
 
 [id="plugins-{type}s-{plugin}-decrement"]
-===== `decrement` 
+===== `decrement`
 
   * Value type is <<hash>>
   * Default value is `{}`
+  * Default decrement by value is `1`
 
 Decrement can be used to decrement a gauge. No other types are supported.
 
@@ -57,18 +58,20 @@ decrement => {
     negaevents_total => {
         description => "This is my test gauge"
         labels => {
-            mylabel => "%{[message]}" 
+            mylabel => "%{[message]}"
         }
+        by => "1"
     }
 }
 ----------------------------------
 
 [id="plugins-{type}s-{plugin}-increment"]
-===== `increment` 
+===== `increment`
 
   * Value type is <<hash>>
   * Default value is `{}`
   * Default type of metric is a `counter`
+  * Default increment by value is `1`
 
 Increment either a gauge or a counter.
 
@@ -79,8 +82,9 @@ increment => {
     events_count => {
         description => "This is my test gauge"
         labels => {
-            mylabel => "%{[message]}" 
+            mylabel => "%{[message]}"
         }
+        by => "1"
     }
 }
 ----------------------------------
@@ -92,15 +96,16 @@ increment => {
     events_total => {
         description => "This is my test gauge"
         labels => {
-            mylabel => "%{[message]}" 
+            mylabel => "%{[message]}"
         }
+        by => "5"
         type => "gauge"
     }
 }
 ----------------------------------
 
 [id="plugins-{type}s-{plugin}-port"]
-===== `port` 
+===== `port`
 
   * Value type is <<number>>
   * Default value is `9640`
@@ -109,7 +114,7 @@ The port that will be used when exposing a metric name.
 With a default port of 9640, Prometheus should be scraping from `https://<yourlogstash>:9640/metrics`
 
 [id="plugins-{type}s-{plugin}-host"]
-===== `host` 
+===== `host`
 
   * Value type is <<string>>
   * Default value is `0.0.0.0`
@@ -131,7 +136,7 @@ set => {
     events_total => {
         description => "This is my test gauge"
         labels => {
-            mylabel => "%{[message]}" 
+            mylabel => "%{[message]}"
         }
         value => "123"
     }
@@ -139,7 +144,7 @@ set => {
 ----------------------------------
 
 [id="plugins-{type}s-{plugin}-timer"]
-===== `timer` 
+===== `timer`
 
   * Value type is <<hash>>
   * Default value is `{}`
@@ -157,7 +162,7 @@ histogramtest => {
   description => "This is my histogram"
   value => "%{[timer]}"
   labels => {
-    mylabel => "%{[message]}" 
+    mylabel => "%{[message]}"
   }
   type => "histogram"
   buckets => [0.1, 1, 5, 10]
@@ -171,7 +176,7 @@ summarytest => {
   description => "This is my summary"
   value => "%{[timer]}"
   labels => {
-    mylabel => "%{[message]}" 
+    mylabel => "%{[message]}"
   }
 }
 ----------------------------------
@@ -183,7 +188,7 @@ summarytest => {
 https://www.robustperception.io/how-should-pipelines-be-monitored
 https://www.robustperception.io/putting-queues-in-front-of-prometheus-for-reliability
 
-// The full list of Value Types is here: 
+// The full list of Value Types is here:
 // https://www.elastic.co/guide/en/logstash/current/configuration-file-structure.html
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/lib/logstash/outputs/prometheus.rb
+++ b/lib/logstash/outputs/prometheus.rb
@@ -47,7 +47,7 @@ class LogStash::Outputs::Prometheus < LogStash::Outputs::Base
     prom_server = $prom_servers[@port]
 
     @increment.each do |metric_name, val|
-    	val = setup_registry_labels(val)
+      val = setup_registry_labels(val)
       if $metrics[port.to_s + metric_name].nil?
         if val['type'] == "gauge"
           metric = prom_server.gauge(metric_name.to_sym, docstring: val['description'], labels: val['labels'].keys)
@@ -92,8 +92,8 @@ class LogStash::Outputs::Prometheus < LogStash::Outputs::Base
   end # def register
 
   def kill_thread()
-  	@thread.kill
-  	$prom_servers[@port] = nil
+    @thread.kill
+    $prom_servers[@port] = nil
   end
 
   protected
@@ -106,19 +106,21 @@ class LogStash::Outputs::Prometheus < LogStash::Outputs::Base
       val['labels'][(key.to_sym rescue key) || key] = val['labels'].delete(key)
     end
 
-    return val     
+    return val
   end
 
   public
   def receive(event)
     @increment.each do |metric_name, val|
       labels = setup_event_labels(val, event)
-      $metrics[port.to_s + metric_name].increment(labels: labels)
+      by = val["by"] ? event.sprintf(val["by"]).to_i : 1
+      $metrics[port.to_s + metric_name].increment(by: by, labels:labels)
     end
 
     @decrement.each do |metric_name, val|
       labels = setup_event_labels(val, event)
-      $metrics[port.to_s + metric_name].decrement(labels: labels)
+      by = val["by"] ? event.sprintf(val["by"]).to_i : 1
+      $metrics[port.to_s + metric_name].decrement(by: by, labels: labels)
     end
 
     @set.each do |metric_name, val|
@@ -139,6 +141,6 @@ class LogStash::Outputs::Prometheus < LogStash::Outputs::Base
       labels[label] = event.sprintf(lval)
     end
 
-    return labels     
+    return labels
   end
 end # class LogStash::Outputs::Prometheus

--- a/spec/outputs/prometheus_spec.rb
+++ b/spec/outputs/prometheus_spec.rb
@@ -9,7 +9,7 @@ describe LogStash::Outputs::Prometheus do
   let(:port) { rand(2000..10000) }
   let(:host) { "0.0.0.0" }
   let(:output) { LogStash::Outputs::Prometheus.new(properties) }
-  let(:secondary_output) { 
+  let(:secondary_output) {
     if secondary_properties.nil?
       LogStash::Outputs::Prometheus.new(properties)
     else
@@ -100,14 +100,15 @@ describe LogStash::Outputs::Prometheus do
 
   describe "counter behavior" do
     let(:properties) {
-      { 
+      {
         "port" => port,
         "host" => host,
-        "increment" => { 
-          "basic_counter" => { 
+        "increment" => {
+          "basic_counter" => {
             "description" => "Test",
+            "by" => "1",
             "labels" => {
-              "mylabel" => "hi" 
+              "mylabel" => "hi"
             }
           }
         }
@@ -115,14 +116,15 @@ describe LogStash::Outputs::Prometheus do
     }
 
     let(:secondary_properties) {
-      { 
+      {
         "port" => port,
         "host" => host,
-        "increment" => { 
-          "basic_counter" => { 
+        "increment" => {
+          "basic_counter" => {
             "description" => "Test",
+            "by" => "1",
             "labels" => {
-              "mylabel" => "boo" 
+              "mylabel" => "boo"
             }
           }
         }
@@ -137,14 +139,15 @@ describe LogStash::Outputs::Prometheus do
   describe "gauge behavior" do
     describe "increment" do
       let(:properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "increment" => { 
-            "basic_gauge" => { 
+          "increment" => {
+            "basic_gauge" => {
               "description" => "Test1",
+              "by" => "1",
               "labels" => {
-                "mylabel" => "hi" 
+                "mylabel" => "hi"
               },
               "type" => "gauge"
             }
@@ -153,15 +156,16 @@ describe LogStash::Outputs::Prometheus do
       }
 
       let(:secondary_properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "increment" => { 
-            "basic_gauge" => { 
+          "increment" => {
+            "basic_gauge" => {
               "description" => "Test1",
+              "by" => "1",
               "type" => "gauge",
               "labels" => {
-                "mylabel" => "boo" 
+                "mylabel" => "boo"
               }
             }
           }
@@ -174,12 +178,13 @@ describe LogStash::Outputs::Prometheus do
 
     describe "decrement" do
       let(:properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "decrement" => { 
-            "basic_gauge" => { 
+          "decrement" => {
+            "basic_gauge" => {
               "description" => "Testone",
+              "by" => "1",
               "type" => "gauge"
             }
           }
@@ -190,11 +195,11 @@ describe LogStash::Outputs::Prometheus do
 
     describe "set" do
       let(:properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "set" => { 
-            "basic_gauge" => { 
+          "set" => {
+            "basic_gauge" => {
               "description" => "Testone",
               "type" => "gauge",
               "value" => "123"
@@ -208,16 +213,16 @@ describe LogStash::Outputs::Prometheus do
 
   describe "summary behavior" do
     let(:properties) {
-      { 
+      {
         "port" => port,
         "host" => host,
-        "timer" => { 
-          "huh" => { 
+        "timer" => {
+          "huh" => {
             "description" => "noway",
             "type" => "summary",
             "value" => "11",
             "labels" => {
-              "mylabel" => "hi" 
+              "mylabel" => "hi"
             }
           }
         }
@@ -225,16 +230,16 @@ describe LogStash::Outputs::Prometheus do
     }
 
     let(:secondary_properties) {
-      { 
+      {
         "port" => port,
         "host" => host,
-        "timer" => { 
-          "huh" => { 
+        "timer" => {
+          "huh" => {
             "description" => "noway",
             "type" => "summary",
             "value" => "10",
             "labels" => {
-              "mylabel" => "boo" 
+              "mylabel" => "boo"
             }
           }
         }
@@ -247,34 +252,34 @@ describe LogStash::Outputs::Prometheus do
   describe "histogram behavior" do
     describe "description" do
       let(:properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "timer" => { 
-            "history" => { 
+          "timer" => {
+            "history" => {
               "description" => "abe",
               "type" => "histogram",
               "buckets" => [1, 5, 10],
               "value" => "0",
               "labels" => {
-                "mylabel" => "hi" 
+                "mylabel" => "hi"
               }
             }
           }
         }
       }
       let(:secondary_properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "timer" => { 
-            "history" => { 
+          "timer" => {
+            "history" => {
               "description" => "abe",
               "type" => "histogram",
               "buckets" => [1, 5, 10],
               "value" => "0",
               "labels" => {
-                "mylabel" => "boo" 
+                "mylabel" => "boo"
               }
             }
           }
@@ -286,11 +291,11 @@ describe LogStash::Outputs::Prometheus do
 
     describe "sum and count" do
       let(:properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "timer" => { 
-            "history" => { 
+          "timer" => {
+            "history" => {
               "description" => "abe",
               "type" => "histogram",
               "buckets" => [1, 5, 10],
@@ -304,11 +309,11 @@ describe LogStash::Outputs::Prometheus do
 
     describe "minimum histogram" do
       let(:properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "timer" => { 
-            "history" => { 
+          "timer" => {
+            "history" => {
               "description" => "abe",
               "type" => "histogram",
               "buckets" => [1, 5, 10],
@@ -322,11 +327,11 @@ describe LogStash::Outputs::Prometheus do
 
     describe "middle histogram" do
       let(:properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "timer" => { 
-            "history" => { 
+          "timer" => {
+            "history" => {
               "description" => "abe",
               "type" => "histogram",
               "buckets" => [1, 5, 10],
@@ -340,11 +345,11 @@ describe LogStash::Outputs::Prometheus do
 
     describe "max histogram" do
       let(:properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "timer" => { 
-            "history" => { 
+          "timer" => {
+            "history" => {
               "description" => "abe",
               "type" => "histogram",
               "buckets" => [1, 5, 10],
@@ -358,11 +363,11 @@ describe LogStash::Outputs::Prometheus do
 
     describe "beyond max histogram" do
       let(:properties) {
-        { 
+        {
           "port" => port,
           "host" => host,
-          "timer" => { 
-            "history" => { 
+          "timer" => {
+            "history" => {
               "description" => "abe",
               "type" => "histogram",
               "buckets" => [1, 5, 10],

--- a/spec/outputs/prometheus_spec.rb
+++ b/spec/outputs/prometheus_spec.rb
@@ -219,16 +219,13 @@ describe LogStash::Outputs::Prometheus do
           "increment" => {
             "basic_gauge" => {
               "description" => "Test1",
-              "by" => "5"
-              "labels" => {
-                "mylabel" => "hi"
-              },
+              "by" => "5",
               "type" => "gauge"
             }
           }
         }
       }
-      include_examples "it should expose data", "basic_gauge 5.0", "# TYPE basic_gauge gauge", "# HELP basic_gauge Testone"
+      include_examples "it should expose data", "basic_gauge 5.0", "# TYPE basic_gauge gauge", "# HELP basic_gauge Test1"
     end
 
     describe "decrement" do

--- a/spec/outputs/prometheus_spec.rb
+++ b/spec/outputs/prometheus_spec.rb
@@ -99,41 +99,79 @@ describe LogStash::Outputs::Prometheus do
   end
 
   describe "counter behavior" do
-    let(:properties) {
-      {
-        "port" => port,
-        "host" => host,
-        "increment" => {
-          "basic_counter" => {
-            "description" => "Test",
-            "by" => "1",
-            "labels" => {
-              "mylabel" => "hi"
+    describe "default increment" do
+      let(:properties) {
+        {
+          "port" => port,
+          "host" => host,
+          "increment" => {
+            "basic_counter" => {
+              "description" => "Test",
+              "labels" => {
+                "mylabel" => "hi"
+              }
             }
           }
         }
       }
-    }
 
-    let(:secondary_properties) {
-      {
-        "port" => port,
-        "host" => host,
-        "increment" => {
-          "basic_counter" => {
-            "description" => "Test",
-            "by" => "1",
-            "labels" => {
-              "mylabel" => "boo"
+      let(:secondary_properties) {
+        {
+          "port" => port,
+          "host" => host,
+          "increment" => {
+            "basic_counter" => {
+              "description" => "Test",
+              "labels" => {
+                "mylabel" => "boo"
+              }
             }
           }
         }
       }
-    }
 
-    include_examples "it should expose data", 'basic_counter{mylabel="hi"} 1', "# TYPE basic_counter counter", "# HELP basic_counter Test"
-    include_examples "it should expose data from multiple outputs", 'basic_counter{mylabel="hi"} 1', 'basic_counter{mylabel="boo"} 1'
+      include_examples "it should expose data", 'basic_counter{mylabel="hi"} 1', "# TYPE basic_counter counter", "# HELP basic_counter Test"
+      include_examples "it should expose data from multiple outputs", 'basic_counter{mylabel="hi"} 1', 'basic_counter{mylabel="boo"} 1'
 
+    end
+
+    describe "custom increment by" do
+      let(:properties) {
+        {
+          "port" => port,
+          "host" => host,
+          "increment" => {
+            "basic_counter" => {
+              "description" => "Test",
+              "by" => "5",
+              "labels" => {
+                "mylabel" => "hi"
+              }
+            }
+          }
+        }
+      }
+
+      let(:secondary_properties) {
+        {
+          "port" => port,
+          "host" => host,
+          "increment" => {
+            "basic_counter" => {
+              "description" => "Test",
+              "by" => "10",
+              "labels" => {
+                "mylabel" => "boo"
+              }
+            }
+          }
+        }
+      }
+
+      include_examples "it should expose data", 'basic_counter{mylabel="hi"} 5', "# TYPE basic_counter counter", "# HELP basic_counter Test"
+      include_examples "it should expose data from multiple outputs", 'basic_counter{mylabel="hi"} 5', 'basic_counter{mylabel="boo"} 10'
+
+    end
   end
 
   describe "gauge behavior" do
@@ -145,7 +183,6 @@ describe LogStash::Outputs::Prometheus do
           "increment" => {
             "basic_gauge" => {
               "description" => "Test1",
-              "by" => "1",
               "labels" => {
                 "mylabel" => "hi"
               },
@@ -162,7 +199,6 @@ describe LogStash::Outputs::Prometheus do
           "increment" => {
             "basic_gauge" => {
               "description" => "Test1",
-              "by" => "1",
               "type" => "gauge",
               "labels" => {
                 "mylabel" => "boo"
@@ -175,6 +211,25 @@ describe LogStash::Outputs::Prometheus do
       include_examples "it should expose data", 'basic_gauge{mylabel="hi"} 1.0', "# TYPE basic_gauge gauge", "# HELP basic_gauge Test1"
       include_examples "it should expose data from multiple outputs", 'basic_gauge{mylabel="hi"} 1', 'basic_gauge{mylabel="boo"} 1'
     end
+    describe "increment with custom by" do
+      let(:properties) {
+        {
+          "port" => port,
+          "host" => host,
+          "increment" => {
+            "basic_gauge" => {
+              "description" => "Test1",
+              "by" => "5"
+              "labels" => {
+                "mylabel" => "hi"
+              },
+              "type" => "gauge"
+            }
+          }
+        }
+      }
+      include_examples "it should expose data", "basic_gauge 5.0", "# TYPE basic_gauge gauge", "# HELP basic_gauge Testone"
+    end
 
     describe "decrement" do
       let(:properties) {
@@ -184,13 +239,29 @@ describe LogStash::Outputs::Prometheus do
           "decrement" => {
             "basic_gauge" => {
               "description" => "Testone",
-              "by" => "1",
               "type" => "gauge"
             }
           }
         }
       }
       include_examples "it should expose data", "basic_gauge -1.0", "# TYPE basic_gauge gauge", "# HELP basic_gauge Testone"
+    end
+
+    describe "decrement with custom by" do
+      let(:properties) {
+        {
+          "port" => port,
+          "host" => host,
+          "decrement" => {
+            "basic_gauge" => {
+              "description" => "Testone",
+              "by" => "10",
+              "type" => "gauge"
+            }
+          }
+        }
+      }
+      include_examples "it should expose data", "basic_gauge -10.0", "# TYPE basic_gauge gauge", "# HELP basic_gauge Testone"
     end
 
     describe "set" do


### PR DESCRIPTION
I needed the plugin to do inc/dec with custom values. Also added some tests for custom "by" cases. One thing I wasn't sure about was if there was a better way to assign a default value for the "by" as the default value is handled by logic rather than configs right now.

Apologies for the extraneous whitespace fixes. Figured I could fix the ones I noticed while I was at it.

This is my first time working with Ruby so apologies if there are any ruby-isms I might have missed. Happy to take feedback.